### PR TITLE
Allow sentences in input

### DIFF
--- a/src/sync_prompt.cc
+++ b/src/sync_prompt.cc
@@ -9,7 +9,7 @@ using namespace std;
 Handle<Value> Prompt(const Arguments& args) {
   HandleScope scope;
   string retval;
-  cin >> retval;
+  getline(cin, retval);
   return scope.Close(String::New(retval.c_str()));
 }
 


### PR DESCRIPTION
As of now, any input with more than one word (ie spaces) acts as if it were two separate inputs. Simply switched cin with getline() to allow for sentences...
