### PR TITLE
Fixed missing includes that prevented build from working with Node 0.11+ on *nix and with Node 0.10+ on Windows

### DIFF
--- a/src/sync_prompt.cc
+++ b/src/sync_prompt.cc
@@ -3,7 +3,9 @@
 #include <iostream>
 #include <string>
 
-#ifndef WIN32
+#ifdef WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
 #endif
 

--- a/src/sync_prompt.cc
+++ b/src/sync_prompt.cc
@@ -7,6 +7,7 @@
 #include <windows.h>
 #else
 #include <unistd.h>
+#include <termios.h>
 #endif
 
 using namespace v8;


### PR DESCRIPTION
I was not able to build/install sync-prompt on Windows without this change. Fixes #14.
